### PR TITLE
Add user list PDF export

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,5 @@ Start automatisch erstellt, falls sie noch nicht existieren.
 - Produkte per Barcode erfassen
 - Buchungen und Bestandsverwaltung
 - Export eines Verbrauchsberichts als PDF
+- Export der Nutzerliste als PDF
 

--- a/admin.py
+++ b/admin.py
@@ -1,5 +1,6 @@
 from db import get_connection
 
+
 def export_pdf(path="report.pdf"):
     """
     Exportiert eine Tabelle mit:
@@ -30,6 +31,29 @@ def export_pdf(path="report.pdf"):
     data = [("Nutzer", "Produkt", "Verbrauch")] + rows
     doc = SimpleDocTemplate(path, pagesize=A4)
     table = Table(data, colWidths=[150, 200, 100])
+    table.setStyle(TableStyle([
+        ("GRID",       (0,0), (-1,-1), 0.5, colors.black),
+        ("BACKGROUND", (0,0), (-1,0),   colors.lightgrey),
+        ("VALIGN",     (0,0), (-1,-1),  "MIDDLE"),
+    ]))
+    doc.build([table])
+
+
+def export_users_pdf(path="users.pdf"):
+    """Exportiert alle Nutzer als Tabelle (ID, Name, PIN)."""
+    from reportlab.lib.pagesizes import A4
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+    from reportlab.lib import colors
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT id, name, pin FROM users ORDER BY id")
+    rows = cur.fetchall()
+    conn.close()
+
+    data = [("ID", "Name", "PIN")] + rows
+    doc = SimpleDocTemplate(path, pagesize=A4)
+    table = Table(data, colWidths=[50, 200, 100])
     table.setStyle(TableStyle([
         ("GRID",       (0,0), (-1,-1), 0.5, colors.black),
         ("BACKGROUND", (0,0), (-1,0),   colors.lightgrey),

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from db import (
     create_product, record_transaction, get_inventory, update_product_count,
     update_pin
 )
-from admin import export_pdf
+from admin import export_pdf, export_users_pdf
 
 def fetch_product_name_online(barcode: str) -> str:
     url = f"https://world.openfoodfacts.org/api/v0/product/{barcode}.json"
@@ -132,6 +132,7 @@ class AdminFrame(tk.Frame):
             ("Bestand anzeigen", self._show_inv),
             ("Bestand bearbeiten", self._edit_inv),
             ("PDF exportieren", self._export),
+            ("Userliste PDF", self._export_users),
             ("PIN ändern", self._edit_pin),
             ("Logout", lambda: master._show_frame(LoginFrame))
         ]
@@ -202,6 +203,11 @@ class AdminFrame(tk.Frame):
         export_pdf()
         messagebox.showinfo("OK","report.pdf erstellt", parent=self)
         webbrowser.open("report.pdf")
+
+    def _export_users(self):
+        export_users_pdf()
+        messagebox.showinfo("OK", "users.pdf erstellt", parent=self)
+        webbrowser.open("users.pdf")
 
 if __name__ == "__main__":
     App().mainloop()

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from db import (
     init_db, authenticate, create_user, create_product,
     record_transaction, get_inventory, update_product_count
 )
-from admin import export_pdf
+from admin import export_pdf, export_users_pdf
 
 def fetch_product_name_online(barcode: str) -> str:
     """
@@ -66,7 +66,8 @@ def admin_menu():
         print("3) Bestand anzeigen")
         print("4) Bestand bearbeiten")
         print("5) PDF-Report exportieren")
-        print("6) Logout")
+        print("6) Userliste exportieren")
+        print("7) Logout")
         choice = input("Auswahl: ").strip()
         if choice == "1":
             pin   = input("Neue PIN: ").strip()
@@ -91,6 +92,8 @@ def admin_menu():
         elif choice == "5":
             export_pdf()
         elif choice == "6":
+            export_users_pdf()
+        elif choice == "7":
             break
         else:
             print("Ungültige Auswahl.")


### PR DESCRIPTION
## Summary
- support exporting all users to PDF in `admin.py`
- expose the feature in CLI and GUI
- document user list export in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684829da1120832abe4b6d9b63022e11