### PR TITLE
Add personal overview for users

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="identifier.sqlite" uuid="6e13f56a-fecf-41d0-b4f6-b5ed509eb017">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:identifier.sqlite</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$/db.py" dialect="GenericSQL" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,12 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="451d06ab-00e8-49c5-91c1-235a60782751" name="Changes" comment="Added Admin Column to Userlist">
-      <change afterPath="$PROJECT_DIR$/.idea/dataSources.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/sqldialects.xml" afterDir="false" />
+    <list default="true" id="451d06ab-00e8-49c5-91c1-235a60782751" name="Changes" comment="Changed the Order and requirements.txt">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app.py" beforeDir="false" afterPath="$PROJECT_DIR$/app.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/requirements.txt" beforeDir="false" afterPath="$PROJECT_DIR$/requirements.txt" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -136,7 +133,7 @@
       <workItem from="1749566211476" duration="2733000" />
       <workItem from="1749570291512" duration="381000" />
       <workItem from="1749725356052" duration="38000" />
-      <workItem from="1749725446656" duration="124000" />
+      <workItem from="1749725446656" duration="692000" />
     </task>
     <task id="LOCAL-00001" summary="start">
       <option name="closed" value="true" />
@@ -178,7 +175,15 @@
       <option name="project" value="LOCAL" />
       <updated>1749560365301</updated>
     </task>
-    <option name="localTasksCounter" value="6" />
+    <task id="LOCAL-00006" summary="Changed the Order and requirements.txt">
+      <option name="closed" value="true" />
+      <created>1749725649815</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1749725649815</updated>
+    </task>
+    <option name="localTasksCounter" value="7" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -200,12 +205,13 @@
     <MESSAGE value="Basic Structure" />
     <MESSAGE value="Added GUI" />
     <MESSAGE value="Added Admin Column to Userlist" />
-    <option name="LAST_COMMIT_MESSAGE" value="Added Admin Column to Userlist" />
+    <MESSAGE value="Changed the Order and requirements.txt" />
+    <option name="LAST_COMMIT_MESSAGE" value="Changed the Order and requirements.txt" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
     <SUITE FILE_PATH="coverage/drinks$db.coverage" NAME="db Coverage Results" MODIFIED="1749479212312" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/drinks$admin.coverage" NAME="admin Coverage Results" MODIFIED="1749480223636" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/drinks$main.coverage" NAME="main Coverage Results" MODIFIED="1749485787659" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
-    <SUITE FILE_PATH="coverage/drinks$app.coverage" NAME="app Coverage Results" MODIFIED="1749570629654" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
+    <SUITE FILE_PATH="coverage/drinks$app.coverage" NAME="app Coverage Results" MODIFIED="1749726121349" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,12 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="451d06ab-00e8-49c5-91c1-235a60782751" name="Changes" comment="Added GUI">
+    <list default="true" id="451d06ab-00e8-49c5-91c1-235a60782751" name="Changes" comment="Added Admin Column to Userlist">
+      <change afterPath="$PROJECT_DIR$/.idea/dataSources.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/sqldialects.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app.py" beforeDir="false" afterPath="$PROJECT_DIR$/app.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/db.py" beforeDir="false" afterPath="$PROJECT_DIR$/db.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/requirements.txt" beforeDir="false" afterPath="$PROJECT_DIR$/requirements.txt" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -52,28 +54,33 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "Python.admin.executor": "Run",
-    "Python.app.executor": "Run",
-    "Python.db.executor": "Run",
-    "Python.main.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "Change__Pin",
-    "ignore.virus.scanning.warn.message": "true",
-    "junie.onboarding.icon.badge.shown": "true",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;Python.admin.executor&quot;: &quot;Run&quot;,
+    &quot;Python.app.executor&quot;: &quot;Run&quot;,
+    &quot;Python.db.executor&quot;: &quot;Run&quot;,
+    &quot;Python.main.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;#9 on codex/eigene-übersicht-für-nutzer-anzeigen&quot;,
+    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
+    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  },
+  &quot;keyToStringList&quot;: {
+    &quot;DatabaseDriversLRU&quot;: [
+      &quot;sqlite&quot;
+    ]
   }
-}]]></component>
+}</component>
   <component name="RunManager">
     <configuration name="app" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="drinks" />
@@ -101,14 +108,17 @@
     <recent_temporary>
       <list>
         <item itemvalue="Python.app" />
+        <item itemvalue="Python.app" />
+        <item itemvalue="Python.app" />
+        <item itemvalue="Python.app" />
       </list>
     </recent_temporary>
   </component>
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
-        <option value="bundled-js-predefined-d6986cc7102b-6a121458b545-JavaScript-PY-251.25410.159" />
-        <option value="bundled-python-sdk-e0ed3721d81e-36ea0e71a18c-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-251.25410.159" />
+        <option value="bundled-js-predefined-d6986cc7102b-b26f3e71634d-JavaScript-PY-251.26094.141" />
+        <option value="bundled-python-sdk-9f8e2b94138c-36ea0e71a18c-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-251.26094.141" />
       </set>
     </attachedChunks>
   </component>
@@ -123,6 +133,10 @@
       <workItem from="1749477988773" duration="201000" />
       <workItem from="1749478530482" duration="4598000" />
       <workItem from="1749552556537" duration="1194000" />
+      <workItem from="1749566211476" duration="2733000" />
+      <workItem from="1749570291512" duration="381000" />
+      <workItem from="1749725356052" duration="38000" />
+      <workItem from="1749725446656" duration="124000" />
     </task>
     <task id="LOCAL-00001" summary="start">
       <option name="closed" value="true" />
@@ -156,7 +170,15 @@
       <option name="project" value="LOCAL" />
       <updated>1749485809731</updated>
     </task>
-    <option name="localTasksCounter" value="5" />
+    <task id="LOCAL-00005" summary="Added Admin Column to Userlist">
+      <option name="closed" value="true" />
+      <created>1749560365300</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1749560365301</updated>
+    </task>
+    <option name="localTasksCounter" value="6" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -177,12 +199,13 @@
     <MESSAGE value="start" />
     <MESSAGE value="Basic Structure" />
     <MESSAGE value="Added GUI" />
-    <option name="LAST_COMMIT_MESSAGE" value="Added GUI" />
+    <MESSAGE value="Added Admin Column to Userlist" />
+    <option name="LAST_COMMIT_MESSAGE" value="Added Admin Column to Userlist" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
     <SUITE FILE_PATH="coverage/drinks$db.coverage" NAME="db Coverage Results" MODIFIED="1749479212312" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/drinks$admin.coverage" NAME="admin Coverage Results" MODIFIED="1749480223636" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/drinks$main.coverage" NAME="main Coverage Results" MODIFIED="1749485787659" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
-    <SUITE FILE_PATH="coverage/drinks$app.coverage" NAME="app Coverage Results" MODIFIED="1749553714111" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
+    <SUITE FILE_PATH="coverage/drinks$app.coverage" NAME="app Coverage Results" MODIFIED="1749570629654" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
   </component>
 </project>

--- a/app.py
+++ b/app.py
@@ -108,13 +108,6 @@ class UserFrame(tk.Frame):
     def __init__(self, master):
         super().__init__(master)
         ttk.Label(self, text="Barcode scannen", font=("Arial",24)).pack(pady=20)
-        self.summary_var = tk.StringVar()
-        tk.Label(
-            self,
-            textvariable=self.summary_var,
-            justify="left",
-            anchor="w",
-        ).pack(pady=5, fill="x", padx=20)
         self.entry = ttk.Entry(self)
         self.entry.pack(pady=5)
         self.entry.focus()
@@ -127,6 +120,13 @@ class UserFrame(tk.Frame):
         ttk.Button(self, text="N\u00e4chster Scan xN", command=self._set_multi).pack(pady=5)
         ttk.Button(self, text="Logout", command=lambda: master._show_frame(LoginFrame)).pack(side="bottom", pady=20)
         self.next_qty = 1
+        self.summary_var = tk.StringVar()
+        tk.Label(
+            self,
+            textvariable=self.summary_var,
+            justify="left",
+            anchor="w",
+        ).pack(pady=5, fill="x", padx=20)
         self.logout_after_id = None
 
     def _restart_timer(self):

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import webbrowser
 from db import (
     init_db, get_user_count, authenticate, create_user,
     create_product, record_transaction, get_inventory, update_product_count,
-    update_pin, delete_user, delete_product
+    update_pin, delete_user, delete_product, get_user_summary
 )
 from admin import export_pdf, export_users_pdf, export_inventory_pdf
 
@@ -154,6 +154,12 @@ class UserFrame(tk.Frame):
         self.qty.delete(0, tk.END)
         self.qty.insert(0, "1")
         self.next_qty = 1
+        summary = get_user_summary(self.master.user[0])
+        if summary:
+            text = "\n".join(f"{n}: {c}" for n, c in summary)
+        else:
+            text = "Keine Buchungen vorhanden."
+        messagebox.showinfo("Übersicht", text, parent=self)
         self.entry.focus()
         self._restart_timer()
 

--- a/app.py
+++ b/app.py
@@ -108,6 +108,13 @@ class UserFrame(tk.Frame):
     def __init__(self, master):
         super().__init__(master)
         ttk.Label(self, text="Barcode scannen", font=("Arial",24)).pack(pady=20)
+        self.summary_var = tk.StringVar()
+        tk.Label(
+            self,
+            textvariable=self.summary_var,
+            justify="left",
+            anchor="w",
+        ).pack(pady=5, fill="x", padx=20)
         self.entry = ttk.Entry(self)
         self.entry.pack(pady=5)
         self.entry.focus()
@@ -159,7 +166,7 @@ class UserFrame(tk.Frame):
             text = "\n".join(f"{n}: {c}" for n, c in summary)
         else:
             text = "Keine Buchungen vorhanden."
-        messagebox.showinfo("Übersicht", text, parent=self)
+        self.summary_var.set(text)
         self.entry.focus()
         self._restart_timer()
 

--- a/app.py
+++ b/app.py
@@ -124,8 +124,8 @@ class UserFrame(tk.Frame):
         tk.Label(
             self,
             textvariable=self.summary_var,
-            justify="left",
-            anchor="w",
+            justify="center",
+            anchor="center",
         ).pack(pady=5, fill="x", padx=20)
         self.logout_after_id = None
 

--- a/db.py
+++ b/db.py
@@ -175,3 +175,23 @@ def delete_product(barcode: str):
         raise ValueError("Barcode nicht gefunden")
     conn.commit()
     conn.close()
+
+
+def get_user_summary(user_id: int):
+    """Return aggregated consumption for a user."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT p.name, COUNT(t.id) as count
+        FROM transactions t
+        JOIN products p ON t.product_id = p.id
+        WHERE t.user_id = ?
+        GROUP BY p.id
+        ORDER BY p.name
+        """,
+        (user_id,)
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return rows

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import requests
 from db import (
     init_db, authenticate, create_user, create_product,
     record_transaction, get_inventory, update_product_count,
-    delete_user, delete_product
+    delete_user, delete_product, get_user_summary
 )
 from admin import export_pdf, export_users_pdf, export_inventory_pdf
 
@@ -137,7 +137,14 @@ def admin_menu(current_user_id: int):
             print("Ungültige Auswahl.")
 
 def user_menu(user_id: int, user_name: str):
-    print(f"\nHallo {user_name}! Bitte Barcode scannen…")
+    summary = get_user_summary(user_id)
+    print(f"\n=== Übersicht für {user_name} ===")
+    if summary:
+        for name, cnt in summary:
+            print(f"{name}: {cnt}")
+    else:
+        print("Keine Buchungen vorhanden.")
+    print("Bitte Barcode scannen…")
     barcode = input().strip()
     record_transaction(user_id, barcode)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask==2.3.2
-reportlab==4.0.0
-requests==2.31.0
+flask >=2.3.2
+reportlab >= 4.0.0
+requests >= 2.31.0


### PR DESCRIPTION
## Summary
- show each non-admin user their consumption overview in CLI and GUI
- add database helper to fetch per-user summary

## Testing
- `python -m py_compile db.py main.py app.py admin.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6848523fc570832aa6d38aeab0633dea